### PR TITLE
Convert Selenium-based framework to Playwright

### DIFF
--- a/PlaywrightCode/.gitignore
+++ b/PlaywrightCode/.gitignore
@@ -1,0 +1,3 @@
+# Playwright specific files
+playwright-report/
+trace.zip

--- a/PlaywrightCode/Actions/LoginActions.cs
+++ b/PlaywrightCode/Actions/LoginActions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using SwagLabProject.PlaywrightCode.Pages;
+
+namespace SwagLabProject.PlaywrightCode.Actions
+{
+    public class LoginActions
+    {
+        private readonly LoginPage _loginPage;
+
+        public LoginActions(IPage page) => _loginPage = new LoginPage(page);
+
+        public async Task LoginAsync(string username, string password)
+        {
+            await _loginPage.EnterUsernameAsync(username);
+            await _loginPage.EnterPasswordAsync(password);
+            await _loginPage.ClickLoginAsync();
+        }
+    }
+}

--- a/PlaywrightCode/Drivers/WebDriverSetup.cs
+++ b/PlaywrightCode/Drivers/WebDriverSetup.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace SwagLabProject.PlaywrightCode.Drivers
+{
+    public class WebDriverSetup
+    {
+        protected IPlaywright playwright;
+        protected IBrowser browser;
+        protected IBrowserContext context;
+        protected IPage page;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            playwright = await Playwright.CreateAsync();
+            browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+            context = await browser.NewContextAsync();
+            page = await context.NewPageAsync();
+            await page.GotoAsync("https://www.saucedemo.com/");
+        }
+
+        [TearDown]
+        public async Task TearDown()
+        {
+            await browser.CloseAsync();
+            playwright.Dispose();
+        }
+    }
+}

--- a/PlaywrightCode/Pages/LoginPage.cs
+++ b/PlaywrightCode/Pages/LoginPage.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace SwagLabProject.PlaywrightCode.Pages
+{
+    public class LoginPage
+    {
+        private readonly IPage _page;
+        private readonly string _usernameField = "#user-name";
+        private readonly string _passwordField = "#password";
+        private readonly string _loginButton = "#login-button";
+
+        public LoginPage(IPage page) => _page = page;
+
+        public async Task EnterUsernameAsync(string username) => await _page.FillAsync(_usernameField, username);
+        public async Task EnterPasswordAsync(string password) => await _page.FillAsync(_passwordField, password);
+        public async Task ClickLoginAsync() => await _page.ClickAsync(_loginButton);
+
+        public async Task<bool> IsOnLoginPageAsync() => (await _page.UrlAsync()).Contains("saucedemo");
+    }
+}

--- a/PlaywrightCode/TestSuite/LoginTests.cs
+++ b/PlaywrightCode/TestSuite/LoginTests.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SwagLabProject.PlaywrightCode.Actions;
+using SwagLabProject.PlaywrightCode.Drivers;
+
+namespace SwagLabProject.PlaywrightCode.TestSuite
+{
+    public class LoginTests : WebDriverSetup
+    {
+        [Test]
+        public async Task Login_WithValidCredentials_ShouldBeSuccessful()
+        {
+            var loginActions = new LoginActions(page);
+            await loginActions.LoginAsync("standard_user", "secret_sauce");
+
+            Assert.That(page.Url.Contains("inventory"), "Login failed!");
+        }
+    }
+}


### PR DESCRIPTION
This PR converts the existing Selenium-based automation framework to Playwright while maintaining the original structure and functionality. The changes include:

- Added Playwright-based `Actions`, `Drivers`, `Pages`, and `TestSuite` under the `PlaywrightCode` folder.
- Updated the `.gitignore` file to include Playwright-specific files.
- Ensured compatibility with NUnit for testing.

closes #<issue_number>