### PR TITLE
Migrate Selenium Tests to Playwright

### DIFF
--- a/PlaywrightCode/Actions/LoginActions.cs
+++ b/PlaywrightCode/Actions/LoginActions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using SwagLabProject.PlaywrightCode.Pages;
+
+namespace SwagLabProject.PlaywrightCode.Actions
+{
+    public class LoginActions
+    {
+        private readonly LoginPage _loginPage;
+
+        public LoginActions(IPage page) => _loginPage = new LoginPage(page);
+
+        public async Task LoginAsync(string username, string password)
+        {
+            await _loginPage.EnterUsernameAsync(username);
+            await _loginPage.EnterPasswordAsync(password);
+            await _loginPage.ClickLoginAsync();
+        }
+    }
+}

--- a/PlaywrightCode/Drivers/WebDriverSetup.cs
+++ b/PlaywrightCode/Drivers/WebDriverSetup.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.PlaywrightCode.Drivers
+{
+    public class WebDriverSetup
+    {
+        protected IPage Page;
+        private IBrowser _browser;
+
+        [SetUp]
+        public async Task SetupAsync()
+        {
+            var playwright = await Playwright.CreateAsync();
+            _browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+            var context = await _browser.NewContextAsync();
+            Page = await context.NewPageAsync();
+            await Page.GotoAsync("https://www.saucedemo.com/");
+        }
+
+        [TearDown]
+        public async Task TearDownAsync()
+        {
+            await _browser.CloseAsync();
+        }
+    }
+}

--- a/PlaywrightCode/Pages/LoginPage.cs
+++ b/PlaywrightCode/Pages/LoginPage.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace SwagLabProject.PlaywrightCode.Pages
+{
+    public class LoginPage
+    {
+        private readonly IPage _page;
+        private readonly string _usernameField = "#user-name";
+        private readonly string _passwordField = "#password";
+        private readonly string _loginButton = "#login-button";
+
+        public LoginPage(IPage page) => _page = page;
+
+        public async Task EnterUsernameAsync(string username) => await _page.FillAsync(_usernameField, username);
+        public async Task EnterPasswordAsync(string password) => await _page.FillAsync(_passwordField, password);
+        public async Task ClickLoginAsync() => await _page.ClickAsync(_loginButton);
+
+        public bool IsOnLoginPage() => _page.Url.Contains("saucedemo");
+    }
+}

--- a/PlaywrightCode/TestSuite/LoginTests.cs
+++ b/PlaywrightCode/TestSuite/LoginTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using SwagLabProject.PlaywrightCode.Actions;
+using SwagLabProject.PlaywrightCode.Drivers;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.PlaywrightCode.TestSuite
+{
+    public class LoginTests : WebDriverSetup
+    {
+        [Test]
+        public async Task Login_WithValidCredentials_ShouldBeSuccessful()
+        {
+            var loginActions = new LoginActions(Page);
+            await loginActions.LoginAsync("standard_user", "secret_sauce");
+
+            Assert.That(Page.Url.Contains("inventory"), "Login failed!");
+        }
+    }
+}


### PR DESCRIPTION
This PR migrates the existing Selenium-based C# automation framework to Playwright. The changes include:
- Conversion of Selenium Actions, Pages, Drivers, and TestSuite to Playwright equivalents.
- Use of Playwright's asynchronous operations and auto-waiting features.
- Structuring code under the `PlaywrightCode/` directory to maintain project organization.

closes #migration-to-playwright